### PR TITLE
Remove `language` config from `config.php`

### DIFF
--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -2,7 +2,6 @@
 $config = array (
   'Config' => 
   array (
-    'language' => 'eng',
     'adminEmail' => 'admin@localhost',
   ),
   'Phonebook' => 


### PR DESCRIPTION
This setting somehow overwrites the language setting comming from `core.php`