### PR TITLE
Added support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,139 @@
+ARG PHP_VERSION=7.4
+FROM php:${PHP_VERSION}-fpm
+
+ARG PHONEBOOK_VERSION=1.0.10
+
+RUN apt-get update -yqq \
+    && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libldap2-dev \
+        zlib1g-dev \
+        libicu-dev \
+        libzip-dev \
+        g++ \
+    # lets mark some packages as manually installed, so they wont be removed by accident
+    && apt-mark manual libzip4 \
+        libpng16-16 \
+        libmcrypt4 \
+        libjpeg62-turbo \
+        libfreetype6 \
+        libcurl3-gnutls \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install -j$(nproc) ldap \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install -j$(nproc) intl \
+    && docker-php-ext-configure zip \
+    && docker-php-ext-install -j$(nproc) zip \
+    && docker-php-ext-install -j$(nproc) bcmath \
+    && docker-php-ext-install -j$(nproc) calendar \
+    && docker-php-ext-install -j$(nproc) iconv \
+    && docker-php-ext-install -j$(nproc) pdo_mysql \
+    && docker-php-ext-install -j$(nproc) mysqli \
+    && docker-php-ext-install -j$(nproc) gettext \
+    && docker-php-ext-install -j$(nproc) exif \
+    && docker-php-ext-configure opcache \
+    && docker-php-ext-install -j$(nproc) opcache \
+    && apt-get remove -y libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libldap2-dev \
+        zlib1g-dev \
+        libicu-dev \
+        libzip-dev \
+        freetype2-doc \
+        g++-8 \
+        icu-devtools \
+        libhashkit-dev \
+        libltdl-dev \
+        libpng-tools \
+        libsasl2-dev \
+        libstdc++-8-dev \
+        libltdl-dev \
+        g++ \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-source delete
+
+RUN apt-get update -yqq \
+    # gettext-base for envsubst, propcs needed by installer
+    && apt-get install -y gettext-base procps \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD https://github.com/anklimsk/internal-ldap-based-phonebook/archive/refs/tags/v$PHONEBOOK_VERSION.tar.gz /tmp/phonebook.tar.gz
+ADD https://getcomposer.org/download/2.1.5/composer.phar /usr/bin/composer
+
+ # 1=english, 2=russian
+ENV PHONEBOOK_LANGUAGE_ID=1 \
+    PHONEBOOK_TIMEZONE=UTC \
+    PHONEBOOK_INIT_WAIT_CREATEDB=180
+
+ENV PHONEBOOK_SECURITY_KEY= \
+    PHONEBOOK_SECURITY_SALT= \
+    PHONEBOOK_SECURITY_CIPHER_SEED=
+
+ENV PHONEBOOK_BASEURL=http://localhost:8080
+
+ENV PHONEBOOK_LDAP_PERSISTENT=false \
+    PHONEBOOK_LDAP_HOST= \
+    PHONEBOOK_LDAP_PORT=389 \
+    PHONEBOOK_LDAP_LOGIN= \
+    PHONEBOOK_LDAP_PASSWORD= \
+    PHONEBOOK_LDAP_BASEDN= \
+    PHONEBOOK_LDAP_TYPE=ActiveDirectory \
+    PHONEBOOK_LDAP_TLS=true \
+    PHONEBOOK_LDAP_VERSION=3
+
+ENV PHONEBOOK_DB_TYPE=Mysql \
+    PHONEBOOK_DB_PERSISTENT=false \
+    PHONEBOOK_DB_HOST= \
+    PHONEBOOK_DB_PORT=3306 \
+    PHONEBOOK_DB_LOGIN= \
+    PHONEBOOK_DB_PASSWORD= \
+    PHONEBOOK_DB_DATABASE=phonebook \
+    PHONEBOOK_DB_SCHEMA= \
+    PHONEBOOK_DB_TABLE_PREFIX= \
+    PHONEBOOK_DB_ENCODING=utf8
+
+RUN mkdir -p /var/www/phonebook \
+    && tar -xvz --directory /var/www/phonebook -f /tmp/phonebook.tar.gz --strip 1 \
+    && rm -f /tmp/phonebook.tar.gz \
+    && chmod +x /usr/bin/composer \
+    && cd /var/www/phonebook \
+    && composer install --optimize-autoloader --no-dev --prefer-dist \
+    && rm -f /usr/bin/composer \
+    && ./app/Console/cake CakeInstaller check \
+    && ./app/Console/cake CakeInstaller setdirpermiss \
+    && ./app/Console/cake CakeInstaller createsymlinks \
+    && chown -R www-data:www-data /var/www/phonebook/app/tmp \
+    && chown -R www-data:www-data /var/www/phonebook/app/Config \
+    && rm -f /var/www/phonebook/app/webroot/test.php
+
+COPY ./docker/docker-entrypoint.sh /usr/local/bin/docker-phonebook-entrypoint
+RUN chmod +x /usr/local/bin/docker-phonebook-entrypoint
+COPY ./docker/database.php.template /var/www/phonebook/app/Config/database.php.template
+
+RUN mkdir -p /tmp/patch
+COPY ./docker/*.patch /tmp/patch/
+RUN cd /var/www/phonebook/ \
+    && patch app/Config/cakeinstaller.php /tmp/patch/cakeinstaller.patch \
+    && rm -rf /tmp/patch
+
+# Build assets
+RUN mkdir -p /usr/share/man/man1 \
+    && apt-get update -yqq \
+    && apt-get install -y default-jre \
+    && cd /var/www/phonebook/ \
+    && ./app/Console/cake asset_compress build \
+    && apt-get remove -y default-jre \
+    && chown -R www-data:www-data /var/www/phonebook/app/tmp \
+    && rm -rf /var/lib/apt/lists/*
+
+USER www-data
+WORKDIR /var/www/phonebook/
+ENTRYPOINT ["/usr/local/bin/docker-phonebook-entrypoint"]
+CMD ["php-fpm"]

--- a/docker/cakeinstaller.patch
+++ b/docker/cakeinstaller.patch
@@ -1,0 +1,42 @@
+# Remove command from installer task
+--- a/app/Config/cakeinstaller.php
++++ b/app/Config/cakeinstaller.php
+@@ -102,27 +102,27 @@
+ 	// Tasks for action - install
+ 	'installTasks' => [
+ 		// Set Installer UI language
+-		'setuilang',
++		//'setuilang',
+ 		// Checking PHP environment
+-		'check',
++		//'check',
+ 		// Set file system permissions on the temporary directory
+-		'setdirpermiss',
++		//'setdirpermiss',
+ 		// Set security key
+-		'setsecurkey',
++		//'setsecurkey',
+ 		// Set timezone
+-		'settimezone',
++		//'settimezone',
+ 		// Set base URL
+-		'setbaseurl',
++		//'setbaseurl',
+ 		// Configure database connections
+-		'configdb',
++		//'configdb',
+ 		// Check connect to database
+-		'connectdb',
++		//'connectdb',
+ 		// Create database and initialize data
+-		'createdb',
++		//'createdb',
+ 		// Create symlinks to files
+-		'createsymlinks',
++		//'createsymlinks',
+ 		// Create cron jobs
+-		'createcronjobs',
++		//'createcronjobs',
+ 	],
+ 	// List of database connection for configure
+ 	'configDBconn' => [

--- a/docker/database.php.template
+++ b/docker/database.php.template
@@ -1,0 +1,33 @@
+<?php
+
+class DATABASE_CONFIG
+{
+
+    public ${DOLLAR}ldap    = [
+        'datasource' => 'CakeLdap.LdapExtSource',
+        'persistent' => '$PHONEBOOK_LDAP_PERSISTENT',
+        'host'       => '$PHONEBOOK_LDAP_HOST',
+        'port'       => $PHONEBOOK_LDAP_PORT,
+        'login'      => '$PHONEBOOK_LDAP_LOGIN',
+        'password'   => '$PHONEBOOK_LDAP_PASSWORD',
+        'database'   => '',
+        'basedn'     => '$PHONEBOOK_LDAP_BASEDN',
+        'type'       => '$PHONEBOOK_LDAP_TYPE',
+        'tls'        => '$PHONEBOOK_LDAP_TLS',
+        'version'    => '$PHONEBOOK_LDAP_VERSION',
+    ];
+
+    public ${DOLLAR}default = [
+        'datasource' => 'Database/$PHONEBOOK_DB_TYPE',
+        'persistent' => '$PHONEBOOK_DB_PERSISTENT',
+        'host'       => '$PHONEBOOK_DB_HOST',
+        'port'       => $PHONEBOOK_DB_PORT,
+        'login'      => '$PHONEBOOK_DB_LOGIN',
+        'password'   => '$PHONEBOOK_DB_PASSWORD',
+        'database'   => '$PHONEBOOK_DB_DATABASE',
+        'schema'     => '$PHONEBOOK_DB_SCHEMA',
+        'prefix'     => '$PHONEBOOK_DB_TABLE_PREFIX',
+        'encoding'   => '$PHONEBOOK_DB_ENCODING',
+    ];
+
+}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set +e
+
+# Script trace mode
+if [ "${DEBUG_MODE,,}" == "true" ]; then
+    set -o xtrace
+fi
+
+CAKE_INSTALLER_MARKER_FILE_INSTALLED=app/tmp/installer/installed.txt
+
+if [ ! -f "$CAKE_INSTALLER_MARKER_FILE_INSTALLED" ]; then
+    cp app/Config/core.php app/Config/core.php.orig
+    cd /var/www/phonebook
+    echo $PHONEBOOK_LANGUAGE_ID | ./app/Console/cake CakeInstaller setuilang
+
+    echo "y" | ./app/Console/cake CakeInstaller setsecurkey
+
+    if [ -z "$PHONEBOOK_SECURITY_SALT" ]; then
+        sed -i -E "s/Configure::write\('Security.salt', '[A-Za-z0-9]+'\);/Configure::write\('Security.salt', '$PHONEBOOK_SECURITY_SALT'\);/" app/Config/core.php
+    fi
+
+    if [ -z "$PHONEBOOK_SECURITY_CIPHER_SEED" ]; then
+        sed -i -E "s/Configure::write\('Security.cipherSeed', '[A-Za-z0-9]+'\);/Configure::write\('Security.cipherSeed', '$PHONEBOOK_SECURITY_CIPHER_SEED'\);/" app/Config/core.php
+    fi
+
+    if [ -z "$PHONEBOOK_SECURITY_KEY" ]; then
+        sed -i -E "s/Configure::write\('Security.key', '[A-Za-z0-9]+'\);/Configure::write\('Security.key', '$PHONEBOOK_SECURITY_KEY'\);/" app/Config/core.php
+    fi
+
+    timezone=`echo $PHONEBOOK_TIMEZONE | sed -E "s#/#\\\\\\\\/#"`
+    sed -i -E "s/\/\/date_default_timezone_set\('UTC'\);/date_default_timezone_set\('$timezone'\);/" app/Config/core.php
+    sed -i -E "s/\/\/Configure::write\('Config.timezone', 'Europe\/Paris'\);/Configure::write\('Config.timezone', '$timezone'\);/" app/Config/core.php
+
+    echo $PHONEBOOK_BASEURL | ./app/Console/cake CakeInstaller setbaseurl
+
+    cp app/Config/database.php app/Config/database.php.orig
+    export DOLLAR=$
+    cat /var/www/phonebook/app/Config/database.php.template | envsubst > /var/www/phonebook/app/Config/database.php
+
+    # sleep a while so the DB is ready
+    echo "Waiting $PHONEBOOK_INIT_WAIT_CREATEDB seconds before initalizing DB"
+    sleep $PHONEBOOK_INIT_WAIT_CREATEDB
+    echo -e "n\ny\nn\ny\nn\ny\nn\ny\n" | ./app/Console/cake CakeInstaller createdb
+
+    # date +"%D %X" > "$CAKE_INSTALLER_MARKER_FILE_INSTALLED
+    echo "y" | ./app/Console/cake CakeInstaller install
+fi
+
+docker-php-entrypoint "$@"


### PR DESCRIPTION
I had to patch the CakeInstaller config, so it the post-install actions are called without going into interactive mode. All needed extensions are installed + opcache.